### PR TITLE
Bugfix: False sorting with a large number of pages

### DIFF
--- a/pico_placing.php
+++ b/pico_placing.php
@@ -34,7 +34,7 @@ class Pico_Placing {
 				$placing_id++;
 			}
 
-			ksort($sorted_pages);
+			ksort($sorted_pages, SORT_STRING);
 			$pages = $sorted_pages;
 
 		}


### PR DESCRIPTION
Large means > 10. It happened that I got indexes for $sorted_pages like '34' and '212'. I just added the SORT_STRING flag to ksort.
