### PR TITLE
Bugfix: Wrong config-key and false if-statement

### DIFF
--- a/pico_placing.php
+++ b/pico_placing.php
@@ -24,7 +24,7 @@ class Pico_Placing {
 
 	public function get_pages(&$pages, &$current_page, &$prev_page, &$next_page) {
 		global $config;
-		if ($config['page_order_by'] = 'placing') {
+		if ($config['pages_order_by'] == 'placing') {
 
 			$sorted_pages = array();
 


### PR DESCRIPTION
Hey guys,
find a little bug in this handy plugin:
The key should be 'pages_order_by' instead of 'page_order_by'. And the if-statement makes an assignment (=) instead of a comparison.
